### PR TITLE
Add github action pipeline for lint and testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,10 +31,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.13', '1.14', '1.15', '1.16']
+        #go: ['1.13', '1.14', '1.15', '1.16']
+        go: ['1.16']
     steps:
       - uses: actions/setup-go@v1
         with:
           go-version: ${{ matrix.go }}
+      - name: install-kubebuilder
+        run: curl -L https://go.kubebuilder.io/dl/2.3.1/$(go env GOOS)/$(go env GOARCH)| tar -xz -C /tmp/ && sudo mv /tmp/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH) /usr/local/kubebuilder
       - uses: actions/checkout@v2
       - run: go test -v -coverprofile=profile.cov ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,16 +25,16 @@ jobs:
         with:
           version: v1.29
           args: --modules-download-mode "vendor"
-#  test:
-##    needs: [ golangci ]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        go: ['1.11', '1.12', '1.13', '1.14', '1.15']
-#    steps:
-#      - uses: actions/setup-go@v1
-#        with:
-#          go-version: ${{ matrix.go }}
-#      - uses: actions/checkout@v2
-#      - run: go test -v -coverprofile=profile.cov ./...
+  test:
+    needs: [ golangci ]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.13', '1.14', '1.15', '1.16']
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+      - uses: actions/checkout@v2
+      - run: go test -v -coverprofile=profile.cov ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,38 @@
+name: tests
+
+on:
+  push:
+#    branches: [ main ]
+#    tags: [ 'v*' ]
+#  pull_request:
+#    branches: [ main ]
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+         go-version: '1.16'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        env:
+          GOPRIVATE: github.com
+          GO111MODULE: "on"
+        with:
+          version: v1.29
+          args: --modules-download-mode "vendor"
+#  test:
+##    needs: [ golangci ]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        go: ['1.11', '1.12', '1.13', '1.14', '1.15']
+#    steps:
+#      - uses: actions/setup-go@v1
+#        with:
+#          go-version: ${{ matrix.go }}
+#      - uses: actions/checkout@v2
+#      - run: go test -v -coverprofile=profile.cov ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,14 @@ jobs:
         with:
           version: v1.29
           args: --modules-download-mode "vendor"
+      - name: gofmt-api
+        uses: Jerome1337/gofmt-action@v1.0.4
+        with:
+          gofmt-path: './api'
+      - name: gofmt-controllers
+        uses: Jerome1337/gofmt-action@v1.0.4
+        with:
+          gofmt-path: './controllers'
   test:
     needs: [ golangci ]
     runs-on: ubuntu-latest
@@ -40,4 +48,4 @@ jobs:
       - name: install-kubebuilder
         run: curl -L https://go.kubebuilder.io/dl/2.3.1/$(go env GOOS)/$(go env GOARCH)| tar -xz -C /tmp/ && sudo mv /tmp/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH) /usr/local/kubebuilder
       - uses: actions/checkout@v2
-      - run: go test -v -coverprofile=profile.cov ./...
+      - run: go test -coverprofile=profile.cov ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,10 +2,11 @@ name: tests
 
 on:
   push:
-#    branches: [ main ]
-#    tags: [ 'v*' ]
-#  pull_request:
-#    branches: [ main ]
+    branches:
+      - main
+      - feature/*
+  pull_request:
+    branches: [ main ]
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-go@v1
         with:
          go-version: '1.16'
+      - name: go-vendor
+        run: go mod vendor
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,14 +25,6 @@ jobs:
         with:
           version: v1.29
           args: --modules-download-mode "vendor"
-      - name: gofmt-api
-        uses: Jerome1337/gofmt-action@v1.0.4
-        with:
-          gofmt-path: './api'
-      - name: gofmt-controllers
-        uses: Jerome1337/gofmt-action@v1.0.4
-        with:
-          gofmt-path: './controllers'
   test:
     needs: [ golangci ]
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,8 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #go: ['1.13', '1.14', '1.15', '1.16']
-        go: ['1.16']
+        go: ['1.15', '1.16']
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ bin
 *~
 
 vendor
-.github

--- a/controllers/taskdefinition_controller.go
+++ b/controllers/taskdefinition_controller.go
@@ -40,7 +40,7 @@ import (
 const (
 	stateActive     = "active"
 	stateSuccessful = "successful"
-        	statePending    = "pending"
+	statePending    = "pending"
 )
 
 // TaskDefinitionReconciler reconciles a TaskDefinition object

--- a/controllers/taskdefinition_controller.go
+++ b/controllers/taskdefinition_controller.go
@@ -40,7 +40,7 @@ import (
 const (
 	stateActive     = "active"
 	stateSuccessful = "successful"
-	statePending    = "pending"
+        	statePending    = "pending"
 )
 
 // TaskDefinitionReconciler reconciles a TaskDefinition object


### PR DESCRIPTION
adds golangci-lint and go test on 1.15 and 1.16 as a pipeline

part of #2 